### PR TITLE
Correctly load config file values

### DIFF
--- a/lib/carthage_cache/configurator.rb
+++ b/lib/carthage_cache/configurator.rb
@@ -36,8 +36,9 @@ module CarthageCache
           raise "Invalid config file" unless valid?(config)
           config.merge(base_config)
         else
-          base_config
+          config = base_config
         end
+        config
       end
 
       def valid?(config)


### PR DESCRIPTION
The bucket name was ignored all the time so it always used the default
`carthage_cache`