### PR TITLE
Lighten the "commander" dependency to work better with Fastlane

### DIFF
--- a/carthage_cache.gemspec
+++ b/carthage_cache.gemspec
@@ -31,5 +31,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "codeclimate-test-reporter"
 
   spec.add_dependency "aws-sdk", "~> 2.2.3"
-  spec.add_dependency "commander", "~> 4.3.8"
+  spec.add_dependency "commander", "~> 4.3"
 end


### PR DESCRIPTION
Because Fastlane for some reasons Fastlane requires `commander` == 4.3.5, `carthage_cache` cannot be used with Fastlane because it requires a more recent version.

This PR simply allows solving the dependencies more easily for Bundler and keep an up-to-date version of Fastlane.