### PR TITLE
Bump version to 0.4.1

### DIFF
--- a/lib/carthage_cache/version.rb
+++ b/lib/carthage_cache/version.rb
@@ -1,3 +1,3 @@
 module CarthageCache
-  VERSION = "0.4.0"
+  VERSION = "0.4.1"
 end


### PR DESCRIPTION
Right after opening https://github.com/guidomb/carthage_cache/issues/19 I realised a PR might have been more appropriate.

The only thing left to do is `rake release` 😄 