### PR TITLE
Local cache

### DIFF
--- a/lib/carthage_cache/archive_installer.rb
+++ b/lib/carthage_cache/archive_installer.rb
@@ -31,8 +31,14 @@ module CarthageCache
 
       def download_archive
         archive_path = File.join(project.tmpdir, project.archive_filename)
-        terminal.puts "Downloading archive with key '#{archive_path}'."
-        repository.download(project.archive_filename, archive_path)
+
+        if File.exist?(archive_path)
+          terminal.puts "Archive with key '#{archive_path}' already downloaded in local cache."
+        else
+          terminal.puts "Downloading archive with key '#{archive_path}'."
+          repository.download(project.archive_filename, archive_path)
+        end
+
         archive_path
       end
 

--- a/lib/carthage_cache/configuration.rb
+++ b/lib/carthage_cache/configuration.rb
@@ -32,7 +32,7 @@ module CarthageCache
           secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
           profile: ENV['AWS_PROFILE']
         },
-        tmpdir: Dir.tmpdir
+        tmpdir: File.join(Dir.home, 'Library', 'Caches', 'carthage_cache')
       })
     end
 

--- a/lib/carthage_cache/configuration.rb
+++ b/lib/carthage_cache/configuration.rb
@@ -32,7 +32,7 @@ module CarthageCache
           secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
           profile: ENV['AWS_PROFILE']
         },
-        tmpdir: File.join(Dir.home, 'Library', 'Caches', 'carthage_cache')
+        tmpdir: File.join(Dir.home, 'Library', 'Caches')
       })
     end
 

--- a/spec/carthage_cache/archive_installer_spec.rb
+++ b/spec/carthage_cache/archive_installer_spec.rb
@@ -11,15 +11,43 @@ describe CarthageCache::ArchiveInstaller do
 
   describe "#install" do
 
-    let(:archive_path) { File.join(project.tmpdir, project.archive_filename) }
+    context "when there is no copy of the archive in the local cache" do
 
-    it "downloads and installs the archive" do
-      # download expectation
-      expect(repository).to receive(:download).with(project.archive_filename, archive_path)
-      # install expectation
-      expect(archiver).to receive(:unarchive).with(archive_path, project.carthage_build_directory)
+      let(:project) { CarthageCache::Project.new(FIXTURE_PATH, cache_dir_name, terminal, TMP_PATH) }
+      let(:archive_path) { File.join(project.tmpdir, project.archive_filename) }
 
-      archive_installer.install
+      it "downloads and installs the archive" do
+        # download expectation
+        expect(repository).to receive(:download).with(project.archive_filename, archive_path)
+        # install expectation
+        expect(archiver).to receive(:unarchive).with(archive_path, project.carthage_build_directory)
+
+        archive_installer.install
+      end
+
+    end
+
+    context "when there is a copy of the archive in the local cache" do
+
+      let(:project) { CarthageCache::Project.new(FIXTURE_WITH_CACHE_PATH, cache_dir_name, terminal, TMP_PATH) }
+      let(:archive_path) { File.join(project.tmpdir, project.archive_filename) }
+
+      before do
+        FileUtils.cp(File.join(FIXTURE_ARCHIVE_PATH, "archive.zip"), archive_path)
+      end
+
+      after do
+        FileUtils.rm(archive_path)
+      end
+
+      it "installs the archive without downloading it" do
+        # without downloading expectation
+        expect(repository).to_not receive(:download)
+        # install expectation
+        expect(archiver).to receive(:unarchive).with(archive_path, project.carthage_build_directory)
+
+        archive_installer.install
+      end
     end
 
   end

--- a/spec/carthage_cache/archive_installer_spec.rb
+++ b/spec/carthage_cache/archive_installer_spec.rb
@@ -14,7 +14,11 @@ describe CarthageCache::ArchiveInstaller do
     let(:archive_path) { File.join(project.tmpdir, project.archive_filename) }
 
     it "downloads and installs the archive" do
+      # download expectation
       expect(repository).to receive(:download).with(project.archive_filename, archive_path)
+      # install expectation
+      expect(archiver).to receive(:unarchive).with(archive_path, project.carthage_build_directory)
+
       archive_installer.install
     end
 

--- a/spec/carthage_cache/configuration_spec.rb
+++ b/spec/carthage_cache/configuration_spec.rb
@@ -4,7 +4,7 @@ describe CarthageCache::Configuration do
 
   describe 'defaults' do
     it 'has ~/Library/Caches/carthage_cache as the default temp directory' do
-      expect(CarthageCache::Configuration.default.tmpdir).to eq File.join(Dir.home, 'Library', 'Caches', 'carthage_cache')
+      expect(CarthageCache::Configuration.default.tmpdir).to eq File.join(Dir.home, 'Library', 'Caches')
     end
   end
 end

--- a/spec/carthage_cache/configuration_spec.rb
+++ b/spec/carthage_cache/configuration_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe CarthageCache::Configuration do
+
+  describe 'defaults' do
+    it 'has ~/Library/Caches/carthage_cache as the default temp directory' do
+      expect(CarthageCache::Configuration.default.tmpdir).to eq File.join(Dir.home, 'Library', 'Caches', 'carthage_cache')
+    end
+  end
+end

--- a/spec/fixtures/project_with_cache/.carthage_cache.yml
+++ b/spec/fixtures/project_with_cache/.carthage_cache.yml
@@ -1,0 +1,6 @@
+---
+:bucket_name: carthage-cache
+:aws_s3_client_options:
+  :region: us-west-2
+  :access_key_id: AAAAAAAAAAAAAAA
+  :secret_access_key: 222222222222222222222222222

--- a/spec/fixtures/project_with_cache/Cartfile
+++ b/spec/fixtures/project_with_cache/Cartfile
@@ -1,0 +1,1 @@
+github "antitypical/Result"

--- a/spec/fixtures/project_with_cache/Cartfile.resolved
+++ b/spec/fixtures/project_with_cache/Cartfile.resolved
@@ -1,0 +1,1 @@
+github "antitypical/Result" "1.0.2"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,4 +8,6 @@ require_relative './mocks/mock_command_executor'
 require_relative './mocks/mock_swift_version_resolver'
 
 FIXTURE_PATH = File.expand_path('../fixtures/project', __FILE__)
+FIXTURE_WITH_CACHE_PATH = File.expand_path('../fixtures/project_with_cache', __FILE__)
 TMP_PATH = File.expand_path('../fixtures/tmp', __FILE__)
+FIXTURE_ARCHIVE_PATH = File.expand_path('../fixtures', __FILE__)


### PR DESCRIPTION
This PR changes `carthage_cache` behaviour so that:

- It uses `~/Library/Caches` rather than a temporary directory as the download destination for the archive.
- It checks in `~/Library/Caches` for the archive matching the current `Cartfile.resolved` + Swift version before attempting to download it from S3.

Marked as "DO NOT MERGE" because it's based on the work from #23. Will rebase on top of `master` once that is approved and/or update as required.

Cheers 😄 