### PR TITLE
Merge configuration sub hashes correctly 

### DIFF
--- a/lib/carthage_cache/configuration.rb
+++ b/lib/carthage_cache/configuration.rb
@@ -68,10 +68,15 @@ module CarthageCache
     end
 
     def merge(c)
+      other_hash = nil
       if c.is_a?(Hash)
-        @hash_object = hash_object.merge(c)
+        other_hash = c
       else
-        @hash_object = hash_object.merge(c.hash_object)
+        other_hash = c.hash_object
+      end
+
+      @hash_object = hash_object.merge(other_hash) do |key, oldval, newval|
+        if oldval.is_a?(Hash) then oldval.merge(newval) end
       end
       self
     end

--- a/spec/carthage_cache/configuration_spec.rb
+++ b/spec/carthage_cache/configuration_spec.rb
@@ -7,4 +7,29 @@ describe CarthageCache::Configuration do
       expect(CarthageCache::Configuration.default.tmpdir).to eq File.join(Dir.home, 'Library', 'Caches')
     end
   end
+
+  describe '#merge' do
+    it 'merges keys in a sub hash without overwriting the existing whole subhash' do
+      expected_hash = { :tmpdir=>"bar", :aws_s3_client_options=>{ :access_key_id=>"foo", :region=>"us-west-2"}}
+      config = CarthageCache::Configuration.new
+      subhash = { :access_key_id=>"foo" }
+      config.hash_object[:tmpdir]="bar"
+      config.hash_object[:aws_s3_client_options]=subhash
+
+      other_subhash = { :region=>"us-west-2" }
+      other_hash = { :aws_s3_client_options=>other_subhash }
+      config.merge(other_hash)
+      expect(config.hash_object).to eq(expected_hash)
+    end
+
+    it 'merges keys from another configuration object into this one correctly' do
+      expected_hash = { :foo=>"bar", :baz=>"bum"}
+      other_config = CarthageCache::Configuration.new
+      other_config.hash_object[:foo]="bar"
+      main_config = CarthageCache::Configuration.new
+      main_config.hash_object[:baz]="bum"
+      main_config.merge(other_config)
+      expect(main_config.hash_object).to eq(expected_hash)
+    end
+  end
 end


### PR DESCRIPTION
This is so that we can set the aws region in .carthage_cache.yml while reading the AWS credentials from the env vars. This keeps the user flow simple as the region is tied to the bucket where as the credentials are usually stored in environmental variables in our use case.