### PR TITLE
Improved to work offline when local cache exists

### DIFF
--- a/lib/carthage_cache/application.rb
+++ b/lib/carthage_cache/application.rb
@@ -22,7 +22,7 @@ module CarthageCache
     end
 
     def archive_exist?
-      repository.archive_exist?(project.archive_path)
+      File.exist?(project.tmp_archive_path) || repository.archive_exist?(project.archive_path)
     end
 
     def install_archive

--- a/lib/carthage_cache/archive_installer.rb
+++ b/lib/carthage_cache/archive_installer.rb
@@ -30,7 +30,7 @@ module CarthageCache
       end
 
       def download_archive
-        archive_path = File.join(project.tmpdir, project.archive_filename)
+        archive_path = project.tmp_archive_path
 
         if File.exist?(archive_path)
           terminal.puts "Archive with key '#{archive_path}' already downloaded in local cache."

--- a/lib/carthage_cache/project.rb
+++ b/lib/carthage_cache/project.rb
@@ -30,6 +30,10 @@ module CarthageCache
       end
     end
 
+    def tmp_archive_path
+      @tmp_archive_path = File.join(tmpdir, archive_filename)
+    end
+
     def archive_key
       cartfile.digest
     end

--- a/spec/carthage_cache/application_spec.rb
+++ b/spec/carthage_cache/application_spec.rb
@@ -51,13 +51,13 @@ describe CarthageCache::Application do
       let(:carthage_build_directory) { File.join(FIXTURE_PATH, "Carthage/Build") }
 
       before(:each) do
-        expect(repository).to receive("archive_exist?").with(archive_filename).and_return(true)
         FileUtils.rm_r(carthage_build_directory) if File.exist?(carthage_build_directory)
       end
 
       context "and no archive in the local cache" do
 
         before(:each) do
+          expect(repository).to receive("archive_exist?").with(archive_filename).and_return(true)
           allow(repository).to receive(:download).with(archive_filename, archive_path) do
             # fake the actual download in the local cache by copying the file
             # there
@@ -83,6 +83,7 @@ describe CarthageCache::Application do
       context "an the archive has already been downloaded in the local cache" do
 
         before(:each) do
+          expect(repository).to_not receive("archive_exist?")
           FileUtils.cp(File.join(TMP_PATH, "archive.zip"), archive_path)
         end
 


### PR DESCRIPTION
Currently, it seems that when `carthage_cache install` is executed, a network request always occurs regardless of whether there is a cache.
So I made it possible to extract offline even if the cache is local.
This is useful when restoring the cache frequently, such as when switching branches.