### PR TITLE
Updates aws-sdk version

### DIFF
--- a/carthage_cache.gemspec
+++ b/carthage_cache.gemspec
@@ -32,6 +32,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   spec.add_development_dependency "rspec_junit_formatter", "~> 0.2.3"
 
-  spec.add_dependency "aws-sdk", "~> 2.0"
+  spec.add_dependency "aws-sdk", "~> 3"
   spec.add_dependency "commander", "~> 4.3"
 end

--- a/lib/carthage_cache/swift_version_resolver.rb
+++ b/lib/carthage_cache/swift_version_resolver.rb
@@ -8,7 +8,7 @@ module CarthageCache
 
     def swift_version
       output = @executor.execute('xcrun swift -version').chomp
-      version_string = /(\d+\.)?(\d+\.)?(\d+)/.match(output).to_s
+      version_string = /(([0-9])+(\.){0,1})+/.match(output).to_s
       Gem::Version.new(version_string)
     end
 


### PR DESCRIPTION
aws-sdk v2.x is being deprecated.

I also had a dependency clash with fastlane where [it now depends on v.3](https://github.com/fastlane/fastlane/commit/13e1b2a13a126d6e96c8c5f09020480a6fa617f1)